### PR TITLE
some changes to make it easier to run tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,5 +10,8 @@ gulp.task('mocha', function(){
         .pipe(mocha({
             reporter: 'spec',
             globals: {}
-        }));
+        }))
+        .once('end', function() {
+          process.exit();
+        });
 });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "files": [
     "lib"
   ],
+  "scripts": {
+    "test": "gulp mocha --harmony"
+  },
   "dependencies": {
     "minimist": "^0.2.0",
     "node-uuid": "^1.4.1",

--- a/test/harness.js
+++ b/test/harness.js
@@ -1,4 +1,5 @@
-var connection = 'postgres://jeremill:@localhost/projections';
+var config = require('../pg-events.json');
+var connection = config.database;
 var projectionFolder = __dirname + '/projections';
 var Promise = require("bluebird");
 var expect = require('chai').expect;


### PR DESCRIPTION
Using 'npm test' to run tests without having to have gulp available as a globally installed module.

Under this usage, the process was not exiting correctly so added a bit to the end of the gulp stream to make it end when mocha ends.

Change the test harness to use the connection provided in pg-events.json.

Now for it to run on my box the only change I'm making is in the pg-events.json file. :)
